### PR TITLE
Fix setup files

### DIFF
--- a/src/rosinstall/setupfiles.py
+++ b/src/rosinstall/setupfiles.py
@@ -265,34 +265,33 @@ CATKIN_SHELL=%(shell)s
 if [ ! -f "$SCRIPT_PATH/setup.sh" ]; then
   echo "Bug: shell script unable to determine its own location: $SCRIPT_PATH"
   return 22
-fi"""%locals()
+fi
 
-    if not no_ros:
-        text += """
-# unset _ros_decode_path to check later whether setup.sh has sourced ros%(shell)s
-unset -f _ros_decode_path 1> /dev/null 2>&1"""%locals()
+# unset _ros_decode_path (function of rosbash) to check later whether setup.sh has sourced ros%(shell)s
+unset -f _ros_decode_path 1> /dev/null 2>&1
 
-    text += """
-. $SCRIPT_PATH/setup.sh"""
+. $SCRIPT_PATH/setup.sh
 
-    if not no_ros:
-        text += """
-# Cannot rely on $? due to set -o errexit in build scripts
-RETURNCODE=`type _ros_decode_path 2> /dev/null | grep function 1>/dev/null 2>&1 || echo error`
+# if we have a ROS_ROOT, then we might need to source rosbash (pre-fuerte)
+if [ ! -z "${ROS_ROOT}" ]; then
+  # check whether setup.sh also already sourced rosbash
+  # Cannot rely on $? due to set -o errexit in build scripts
+  RETURNCODE=`type _ros_decode_path 2> /dev/null | grep function 1>/dev/null 2>&1 || echo error`
 
-# for ROS electric and before, source rosbash
-if [ ! "$RETURNCODE" = "" ]; then
-  RETURNCODE=`rospack help 1> /dev/null 2>&1 || echo error`
-  if  [ "$RETURNCODE" = "" ]; then
-    ROSSHELL_PATH=`rospack find rosbash`/ros%(shell)s
-    if [ -e "$ROSSHELL_PATH" ]; then
-      . $ROSSHELL_PATH
+  # for ROS electric and before, source rosbash
+  if [ ! "$RETURNCODE" = "" ]; then
+    RETURNCODE=`rospack help 1> /dev/null 2>&1 || echo error`
+    if  [ "$RETURNCODE" = "" ]; then
+      ROSSHELL_PATH=`rospack find rosbash`/ros%(shell)s
+      if [ -e "$ROSSHELL_PATH" ]; then
+        . $ROSSHELL_PATH
+      fi
+    else
+      echo "rospack could not be found, you cannot have ros%(shell)s features until you bootstrap ros"
     fi
-  else
-    echo "rospack could not be found, you cannot have ros%(shell)s features until you bootstrap ros"
   fi
 fi
-"""%locals()
+""" % locals()
     return text
 
 


### PR DESCRIPTION
for review:

changed the generated setup.\* files a bit.
the first commit becomes irrelevant with the third, added just for the records

The second commit avoids exporting ROS_ROT in fuerte and later, when it was exported anyway. This also prevents the PYTHONPATH from getting an unexisting path added.

This commit causes setup.bash to be the same regardless of whether rosws detected a ROS_ROOT or not. (rosws is less strict than rosinstall about having a ROS ROOT at all).
setup.bash will check whether it should source rosbash only if ROS_ROOT was set
