### PR TITLE
Extend rpp from setup

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 - missing newline on error output
 - fix bug around -t option parsing
 - fix #27 missing import of sys
+- fix ROS_PACKAGE_PATH set by referenced setup-file overwritten
 
 0.6.21
 ------

--- a/src/rosinstall/setupfiles.py
+++ b/src/rosinstall/setupfiles.py
@@ -174,6 +174,9 @@ _ROS_PACKAGE_PATH_ROSINSTALL=`echo "$_PARSED_CONFIG" | sed 's,\(.*\)ROSINSTALL_P
 _SETUPFILES_ROSINSTALL=`echo "$_PARSED_CONFIG" | sed 's,\(.*\)'ROSINSTALL_PATH_SETUPFILE_SEPARATOR'\(.*\),\\2,'`
 unset _PARSED_CONFIG
 
+# reset RPP before running setup files
+export ROS_PACKAGE_PATH=
+
 # colon separates entries
 _LOOP_SETUP_FILE=`echo $_SETUPFILES_ROSINSTALL | sed 's,\([^:]*\)[:]\(.*\),\\1,'`
 while [ ! -z "$_LOOP_SETUP_FILE" ]
@@ -190,7 +193,11 @@ done
 unset _LOOP_SETUP_FILE
 unset _SETUPFILES_ROSINSTALL
 
-export ROS_PACKAGE_PATH=$_ROS_PACKAGE_PATH_ROSINSTALL
+if [ ! "$ROS_PACKAGE_PATH" ]; then
+  export ROS_PACKAGE_PATH=$_ROS_PACKAGE_PATH_ROSINSTALL
+else
+  export ROS_PACKAGE_PATH=$_ROS_PACKAGE_PATH_ROSINSTALL:$ROS_PACKAGE_PATH
+fi
 unset _ROS_PACKAGE_PATH_ROSINSTALL
 
 # if setup.sh did not set ROS_ROOT (pre-fuerte)


### PR DESCRIPTION
for review (code is trivial, but semantics are not):

fix for #29
There is a caveat. The behavior remains same for electric and before,since those do not use setup-file elements.
In Fuerte however, the RPP will change with the patch, because there is a setup-file,and this setup-file also sets the RPP. So with fuerte we get in the simple overlay case:

before the patch:
$ source setup.bash; echo $ROS_PACKAGE_PATH
/opt/ros/fuerte/stacks:/opt/ros/fuerte/share:/opt/ros/fuerte/share/ros
after the patch:
$ source setup.bash; echo $ROS_PACKAGE_PATH
/opt/ros/fuerte/stacks:/opt/ros/fuerte/share:/opt/ros/fuerte/share/ros:/opt/ros/fuerte/share:/opt/ros/fuerte/stacks

This is ugly, but I think it is benign. Not sure how we could fix #29 else.
