### PR TITLE
new param allow_other_element to be set to False in wstool.

### DIFF
--- a/src/rosinstall/config_yaml.py
+++ b/src/rosinstall/config_yaml.py
@@ -139,7 +139,7 @@ def rewrite_included_source(source_path_specs, source_dir):
     return source_path_specs
 
 
-def aggregate_from_uris(config_uris, config_filename=None):
+def aggregate_from_uris(config_uris, config_filename=None, allow_other_element=True):
     """
     Builds a List of PathSpec from a list of location strings (uri,
     paths). If locations is a folder, attempts to find config_filename in it,
@@ -149,6 +149,7 @@ def aggregate_from_uris(config_uris, config_filename=None):
 
     :param config_uris: source of yaml
     :param config_filename: file to use when given a folder
+    :param allow_other_element: if False, discards elements to be added without SCM information
     """
     aggregate_source_yaml = []
     # build up a merged list of config elements from all given config_uris
@@ -158,6 +159,11 @@ def aggregate_from_uris(config_uris, config_filename=None):
             # deal with duplicates in Config class
             if source_path_specs is not None:
                 assert type(source_path_specs) == list, 'Probable bug: expected list, was %s' % type(source_path_specs)
+                if not allow_other_element:
+                    for spec in source_path_specs:
+                        if not spec.get_scmtype():
+                            raise MultiProjectException("Forbidden non-SCM element: %s (%s)" %
+                                  (spec.get_local_name(), spec.get_legacy_type()))
                 aggregate_source_yaml.extend(source_path_specs)
     return aggregate_source_yaml
 

--- a/src/rosinstall/multiproject_cmd.py
+++ b/src/rosinstall/multiproject_cmd.py
@@ -103,7 +103,10 @@ def get_config(basepath,
     return config
 
 
-def add_uris(config, additional_uris, merge_strategy="KillAppend"):
+def add_uris(config,
+             additional_uris,
+             merge_strategy="KillAppend",
+             allow_other_element=True):
     """
     changes the given config by merging with the additional_uris
 
@@ -111,6 +114,7 @@ def add_uris(config, additional_uris, merge_strategy="KillAppend"):
     :param additional_uris: the location of config specifications or folders
     :param config_filename: name of files which may be looked at for config information
     :param merge_strategy: One of 'KillAppend, 'MergeKeep', 'MergeReplace'
+    :param allow_other_element: if False, discards elements to be added with no SCM information
     :returns: a dict {<local-name>: (<action>, <path-spec>), <local-name>: ...} determined by the merge_strategy
     :raises MultiProjectException: on plenty of errors
     """
@@ -146,7 +150,8 @@ def add_uris(config, additional_uris, merge_strategy="KillAppend"):
     actions = {}
     if len(added_uris) > 0:
         path_specs = aggregate_from_uris(added_uris,
-                                         config.get_config_filename())
+                                         config.get_config_filename(),
+                                         allow_other_element)
         for path_spec in path_specs:
             action = config.add_path_spec(path_spec, merge_strategy)
             actions[path_spec.get_local_name()] = (action, path_spec)

--- a/src/rosinstall/rosws_cli.py
+++ b/src/rosinstall/rosws_cli.py
@@ -81,6 +81,7 @@ class RoswsCLI(MultiprojectCLI):
         MultiprojectCLI.__init__(self,
                                  progname=progname,
                                  config_filename=config_filename,
+                                 allow_other_element=True,
                                  config_generator=rosinstall_cmd.cmd_persist_config)
 
     def cmd_init(self, argv):

--- a/test/local/test_cli.py
+++ b/test/local/test_cli.py
@@ -576,11 +576,25 @@ class MultiprojectCLITest(AbstractFakeRosBasedTest):
         self.assertTrue(os.path.exists(os.path.join(self.local_path, 'gitrepo')))
         self.assertTrue(os.path.exists(os.path.join(self.local_path, 'hgrepo')))
 
+    def test_cmd_set(self):
+        self.local_path = os.path.join(self.test_root_path, "ws31b")
+        cli = MultiprojectCLI(progname='multi_cli', config_filename='.rosinstall')
+        self.assertEqual(0, cli.cmd_init([self.local_path, self.simple_rosinstall, "--parallel=5"]))
+        self.assertTrue(os.path.exists(os.path.join(self.local_path, '.rosinstall')))
+        self.assertTrue(os.path.exists(os.path.join(self.local_path, 'gitrepo')))
+        self.assertFalse(os.path.exists(os.path.join(self.local_path, 'hgrepo')))
+        self.assertRaises(SystemExit, cli.cmd_set, os.path.join(self.local_path, 'hgrepo'), ["--detached"])
+        cli = MultiprojectCLI(progname='multi_cli', config_filename='.rosinstall', allow_other_element=True)
+        # self.assertEqual(0, cli.cmd_set(os.path.join(self.local_path, 'hgrepo'), ["--detached"]))
+
     def test_cmd_remove(self):
         # rosinstall to create dir
         self.local_path = os.path.join(self.test_root_path, "ws32")
-        cli = MultiprojectCLI(progname='multi_cli', config_filename='.rosinstall')
+        cli = MultiprojectCLI(progname='multi_cli', config_filename='.rosinstall', allow_other_element=False)
         self.assertEqual(0, cli.cmd_init([self.local_path]))
+        self.assertRaises(MultiProjectException, cli.cmd_merge, self.local_path, [self.git_path, "-y"])
+        self.assertRaises(MultiProjectException, cli.cmd_merge, self.local_path, [self.hg_path, "-y"])
+        cli = MultiprojectCLI(progname='multi_cli', config_filename='.rosinstall', allow_other_element=True)
         self.assertEqual(0, cli.cmd_merge(self.local_path, [self.git_path, "-y"]))
         self.assertEqual(0, cli.cmd_merge(self.local_path, [self.hg_path, "-y"]))
         config = rosinstall.multiproject_cmd.get_config(basepath=self.local_path,
@@ -591,7 +605,7 @@ class MultiprojectCLITest(AbstractFakeRosBasedTest):
                                                         config_filename='.rosinstall')
         self.assertEqual(len(config.get_config_elements()), 1)
 
-    def test_cmd_add(self):
+    def test_cmd_add_uris(self):
         # rosinstall to create dir
         self.local_path = os.path.join(self.test_root_path, "ws33")
         cli = MultiprojectCLI(progname='multi_cli', config_filename='.rosinstall')

--- a/test/local/test_config_yaml.py
+++ b/test/local/test_config_yaml.py
@@ -149,6 +149,11 @@ class UriAggregationTest(unittest.TestCase):
         rosinstall.config_yaml.generate_config_yaml(config, 'foo', "# Hello\n")
         ryaml = aggregate_from_uris([self.directory], config.get_config_filename())
         self.assertEqual(ryaml[0].get_legacy_yaml(), {'other': {'local-name': self.directory}})
+        self.assertRaises(MultiProjectException,
+                          aggregate_from_uris,
+                          [self.directory],
+                          config.get_config_filename(),
+                          allow_other_element=False)
 
     def tearDown(self):
         if os.path.exists(self.directory):


### PR DESCRIPTION
Raises errors when trying to add non SCM elements (other, setup-file) to a .rosinstall via a wstool command.
Ignores such entries (manually added to file) else.

Follows Draft REP 133
