### PR TITLE
fix #59 chaining of setup.sh files generated by rosinstall/rosws

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -7,6 +7,7 @@ Changelog
 0.6.25
 ------
 
+- fix #59: Invalid ROS_PACKAGE_PATH when chaining rosws generated workspaces via setup-file elements
 - fix regression breaking wstool set command
 - fix rosws regenrate missing -t option
 


### PR DESCRIPTION
The previous behavior only worked when a rosws workspace overlayed
e.g. /opt/ros/fuerte, but generated an invalid ROS_PACKAGE_PATH when
chaining another rosws workspace using the setup-file element

The cause was that the env variables used in setup.sh got changed
in the recursion.

The solution here is to use the global variables in the recursion,
as an accumulator for the ROS_PACKAGE_PATH, and a producer-consumer
stack for the list of setup files to source.
This implied preventing variables to be accidentally reset or unset
in nested calls to setup.sh files,

A new test tests chaining twice and chaining more than one setup-file
element, to prevent regressions.
