### PR TITLE
use vcstool wrapper of urlopen using netrc

### DIFF
--- a/src/rosinstall/config_yaml.py
+++ b/src/rosinstall/config_yaml.py
@@ -54,16 +54,20 @@ def get_yaml_from_uri(uri):
     try:
         try:
             if os.path.isfile(uri):
-                stream = open(uri, 'r')
+                try:
+                    stream = open(uri, 'r')
+                except IOError as ioe:
+                    raise MultiProjectException(
+                        "Unable open file [%s]: %s" % (uri, ioe))
             else:
-                stream = urlopen_netrc(uri)
-        except IOError as ioe:
-            raise MultiProjectException(
-                "Is not a local file, nor able to download as a URL [%s]: %s" % (uri, ioe))
+                try:
+                    stream = urlopen_netrc(uri)
+                except IOError as ioe2:
+                    raise MultiProjectException(
+                        "Unable to download URL [%s]: %s" % (uri, ioe2))
         except ValueError as vae:
             raise MultiProjectException(
                 "Is not a local file, nor a valid URL [%s] : %s" % (uri, vae))
-
         if not stream:
             raise MultiProjectException("couldn't load config uri %s" % uri)
         try:


### PR DESCRIPTION
For review (should be quick) and merge after this one:
https://github.com/vcstools/vcstools/pull/60

This should make it possible to merge with rosinstalls lying on bitbucket in a private repo, using netrc credentials to access the url.
E.g. 

```
../scripts/rosws merge https://bitbucket.org/tkruse/rosinstalls/master/raw/test.rosinstall
```

should be possible if there is a file ~/.netrc with contents like

```
machine bitbucket.org login <user> password <password>
```
