### PR TITLE
Allow for gitfile mechanism for submodules

### DIFF
--- a/src/rosinstall/config_elements.py
+++ b/src/rosinstall/config_elements.py
@@ -457,7 +457,7 @@ class AVCSConfigElement(VCSConfigElement):
         # to make more use of lazy initializer, do not instantiate
         # client for just this this is crucial for bash tab completion
         if self.get_vcs_type_name() == 'git':
-            return os.path.isdir(os.path.join(self.path, '.git'))
+            return os.path.exists(os.path.join(self.path, '.git'))
         elif self.get_vcs_type_name() == 'svn':
             return os.path.isdir(os.path.join(self.path, '.svn'))
         elif self.get_vcs_type_name() == 'hg':


### PR DESCRIPTION
Changed detect_presence() to use os.path.exist() for git to accomodate gitfile mechanism.
Tried it out by recursively cloning a supermodule, then running the following command:

git submodule-ext --no-cd 'rosws set -y $path --git $(cd $path && git config remote.origin.url)'

(NOTE: git submodule-ext is a modded command here: https://github.com/eacousineau/util)
Worked for updating branches.

This would allow users to initialize a workspace inside a supermodule if they choose and still be able to update submodules it via `rosws update`.

Goal here was trying to bridge between rosinstall (bulk install, familiarity) and git submodules (granularity for tracking precise commits, url updating, etc.)
Maybe this would be useful if the non-git repos are cloned with remote-helpers or in ignored?
