### PR TITLE
Update documentation link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ rosinstall
 
 Command-line tools for maintaining a workspace of projects from multiple version-control systems, tailored for the ROS (Robot operating system) community.
 
-See http://www.ros.org/doc/api/rosinstall/html
+See http://docs.ros.org/independent/api/rosinstall/html
 
 Installing
 ----------


### PR DESCRIPTION
The link in the README.rst file didn't seem to work for me. I have replaced it with a link that Google knew about and seems to have the content now.