### PR TITLE
Add default ROS_ROOT for rosbuild

### DIFF
--- a/src/rosinstall/setupfiles.py
+++ b/src/rosinstall/setupfiles.py
@@ -290,6 +290,10 @@ EOPYTHON`
 unset _ROS_ROOT_ROSINSTALL
 fi
 
+if [ -z "${ROS_ROOT}" ]; then
+  export ROS_ROOT=/usr/share/ros
+fi
+
 if [ ! -z "$_SETUP_SH_ERROR" ]; then
   # return failure code when sourcing file
   false


### PR DESCRIPTION
From @jspricke's [debian patch](http://anonscm.debian.org/cgit/debian-science/packages/ros/ros-rosinstall.git/tree/debian/patches/0001-Add-default-ROS_ROOT-for-rosbuild.patch):

I'm not advocating for or against the patch, just promoting its visibility since it is being used in the debian version of ROS.
