### PR TITLE
[vcstools/wstool#96] Provide --shallow option in rosco

### DIFF
--- a/scripts/rosco
+++ b/scripts/rosco
@@ -95,6 +95,7 @@ def rosco_main():
 Checks out out ros packages or stacks into local directory.
 \trosco [options] <package-or-stack>
 \trosco -r <rosinstall-file>
+\trosco --help
 
 rosco also accepts piped rosinstall input:
 
@@ -109,6 +110,10 @@ rosco also accepts piped rosinstall input:
                       dest="dev", default=False,
                       action="store_true",
                       help="fetch development branch information")
+    parser.add_option("--shallow",
+                      dest="shallow", default=False,
+                      action="store_true",
+                      help="True/False, hint to prefer checkout of only latest revision, if possible")
     options, args = parser.parse_args()
 
     # accept piped input
@@ -137,7 +142,7 @@ rosco also accepts piped rosinstall input:
         parser.error("input must be a rosinstall snippet")
 
     try:
-        checkout_rosinstall(rosinstall_data, verbose=True)
+        checkout_rosinstall(rosinstall_data, verbose=True, shallow=options.shallow)
     except MultiProjectException as mpe:
         sys.exit(mpe)
 

--- a/src/rosinstall/simple_checkout.py
+++ b/src/rosinstall/simple_checkout.py
@@ -35,9 +35,11 @@ import vcstools
 from wstool.config_yaml import get_path_spec_from_yaml
 
 
-def checkout_rosinstall(rosinstall_data, verbose=False):
+def checkout_rosinstall(rosinstall_data, verbose=False, shallow=False):
     """
     :param rosinstall_data: yaml dict in rosinstall format
+    :param verbose: verbose output
+    :param shallow: hint to use shallow checkout
     :raises: rosinstall.common.MultiProjectException for incvalid yaml
     """
     for frag in rosinstall_data:
@@ -51,4 +53,5 @@ def checkout_rosinstall(rosinstall_data, verbose=False):
         vcs_client = vcstools.get_vcs_client(path_spec.get_scmtype(),
                                              path_spec.get_path())
         vcs_client.checkout(path_spec.get_uri(),
-                            path_spec.get_version())
+                            path_spec.get_version(),
+                            shallow=shallow)


### PR DESCRIPTION
See vcstools/wstool#96

Currently this only affects git in vcstools.
Also, in vcstools, shallow git clones automatically have option ' --no-single-branch', which means the tip of each branch would be checked out, which reduces the benefit of shallow clones somewhat in the scenario of CI checkouts, where a lot of branches are present. That was done by @cottsay in 2013, I cannot remember if there was a discussion about it. Not sure if this is a major problem.


BTW, since git 2.9.0, it seems there is an option for shallow submodule clones:
https://github.com/git/git/blob/726cc2ba12c4573ab2e623077479c51019e1f3cd/Documentation/RelNotes/2.9.0.txt#L116
might be nice to add it to git.py.
