### PR TITLE
prepare 0.7.9 release

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,3 +66,27 @@ To test on your local machine you can call make install, with checkinstall insta
 
 To release make sure that the version number in src/rosinstall/__version__.py and that the doc/changelog.rst are updated.
 
+* Upgrade vcstools/wstool dependency version in `setup.py`
+* Update `src/vcstools/__version__.py`
+* Check `doc/changelog` is up to date
+* Check `stdeb.cfg` is up to date with OSRF buildfarm distros
+* prepare release dependencies::
+
+      pip install --upgrade setuptools wheel twine
+
+* Upload to testpypi::
+
+      python3 setup.py sdist bdist_wheel
+      twine upload --repository testpypi dist/*
+
+* Check testpypi download files and documentation look ok
+* Actually release::
+
+      twine upload dist/*
+
+* Create and push tag::
+
+      git tag x.y.z
+      git push
+      git push --tags
+

--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+0.7.9
+-----
+
+- using pyyaml safe_load to avoid warning messages
+- upgrade vcstools library version to 0.1.41, with new fixes:
+
+  - fix git submodule errors
+  - fix export_upstream for git submodules
+  - fix python3 incompatibility
+  - fix git fast-forward failures
+  - fix get_affected_files  
+
+0.7.8
+-----
+
+- Maintenance release
+
 0.7.7
 -----
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-vcstools>=0.1.38
+vcstools>=0.1.42
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -34,11 +34,11 @@ setup(name='rosinstall',
       packages=['rosinstall'],
       package_dir={'': 'src'},
       install_requires=[
-          'vcstools>=0.1.38',
+          'vcstools>=0.1.42',
           'pyyaml',
           'rosdistro>=0.3.0',
           'catkin_pkg',
-          'wstool>=0.1.14',
+          'wstool>=0.1.18',
           'rospkg'
       ],
       tests_require=test_required,

--- a/src/rosinstall/__version__.py
+++ b/src/rosinstall/__version__.py
@@ -1,1 +1,1 @@
-version = '0.7.8'
+version = '0.7.9'

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: subversion, mercurial, git-core, bzr, python-yaml, python-vcstools (>= 
 Depends3: subversion, mercurial, git-core, bzr, python3-yaml, python3-vcstools (>= 0.1.38), python3-catkin-pkg, python3-rosdistro (>=0.3.0), python3-wstool (>=0.1.14), python3-rospkg
 Conflicts: python3-rosinstall
 Conflicts3: python-rosinstall
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco wheezy jessie stretch buster
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic wheezy jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
@wjwwood : This is ready to be released after https://github.com/vcstools/wstool/pull/140

Travis failure because new vcstools not released yet.

Feel free to look over the last merged commits.
I'll go ahead with in a week else.