### PR TITLE
Update release suites.

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: subversion, mercurial, git-core, bzr, python-yaml, python-vcstools (>= 
 Depends3: subversion, mercurial, git-core, bzr, python3-yaml, python3-vcstools (>= 0.1.38), python3-catkin-pkg, python3-rosdistro (>=0.3.0), python3-wstool (>=0.1.14), python3-rospkg
 Conflicts: python3-rosinstall
 Conflicts3: python-rosinstall
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan wheezy jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.2

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: subversion, mercurial, git-core, bzr, python-yaml, python-vcstools (>= 
 Depends3: subversion, mercurial, git-core, bzr, python3-yaml, python3-vcstools (>= 0.1.38), python3-catkin-pkg, python3-rosdistro (>=0.3.0), python3-wstool (>=0.1.14), python3-rospkg
 Conflicts: python3-rosinstall
 Conflicts3: python-rosinstall
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco wheezy jessie stretch buster
+Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan wheezy jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Cosmic, Disco, and Eoan are now live on the ROS bootstrap repository and future releases should be pushed to them as well.

The second commit also drops suites older than Ubuntu Xenial and Debian Jessie