### PR TITLE
Remove old platforms from py3 release, add Suite3 option with focal

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -4,4 +4,5 @@ Depends3: subversion, mercurial, git-core, bzr, python3-yaml, python3-vcstools (
 Conflicts: python3-rosinstall
 Conflicts3: python-rosinstall
 Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
+Suite3: xenial yakkety zesty artful bionic cosmic disco eoan focal jessie stretch buster
 X-Python3-Version: >= 3.2

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -3,5 +3,5 @@ Depends: subversion, mercurial, git-core, bzr, python-yaml, python-vcstools (>= 
 Depends3: subversion, mercurial, git-core, bzr, python3-yaml, python3-vcstools (>= 0.1.38), python3-catkin-pkg, python3-rosdistro (>=0.3.0), python3-wstool (>=0.1.14), python3-rospkg
 Conflicts: python3-rosinstall
 Conflicts3: python-rosinstall
-Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco wheezy jessie stretch buster
+Suite: xenial yakkety zesty artful bionic cosmic disco eoan jessie stretch buster
 X-Python3-Version: >= 3.2


### PR DESCRIPTION
Mimicking ros-infrastructure/catkin_pkg#271 and vcstools/wstool#148