### PR TITLE
Switch to use the module debian packages not command line packages

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,6 +1,6 @@
 [DEFAULT]
-Depends: subversion, mercurial, git-core, bzr, python-yaml, python-vcstools (>= 0.1.38), python-catkin-pkg, python-rosdistro (>=0.3.0), python-wstool (>=0.1.14), python-rospkg
-Depends3: subversion, mercurial, git-core, bzr, python3-yaml, python3-vcstools (>= 0.1.38), python3-catkin-pkg, python3-rosdistro (>=0.3.0), python3-wstool (>=0.1.14), python3-rospkg
+Depends: subversion, mercurial, git-core, bzr, python-yaml, python-vcstools (>= 0.1.38), python-catkin-pkg-modules, python-rosdistro-modules (>=0.3.0), python-wstool (>=0.1.14), python-rospkg-modules
+Depends3: subversion, mercurial, git-core, bzr, python3-yaml, python3-vcstools (>= 0.1.38), python3-catkin-pkg-modules, python3-rosdistro-modules (>=0.3.0), python3-wstool (>=0.1.14), python3-rospkg-modules
 Conflicts: python3-rosinstall
 Conflicts3: python-rosinstall
 Suite: oneiric precise quantal raring saucy trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco wheezy jessie stretch buster


### PR DESCRIPTION
This will allow better coexistance between python2 and python3 versions of toolchains otherwise you can't install python-rosinstall on a system with ROS 2.