### PR TITLE
Also run tests with Python 3.7 and 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
 # command to install dependencies
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ python:
 
 # command to install dependencies
 install:
+  # newer versions of docutils dropped support for Python 3.4
+  - if [ $TRAVIS_PYTHON_VERSION == "3.4" ]; then pip install docutils==0.15.2; else pip install docutils; fi
   # easy_install fails to install wstool as a dependency
   # https://github.com/vcstools/rosinstall/pull/116
   - pip install wstool


### PR DESCRIPTION
Debian Buster uses Python 3.7 and Ubuntu Focal will use Python 3.8